### PR TITLE
Add '/permissions' endpoint

### DIFF
--- a/feeds/activity/notification.py
+++ b/feeds/activity/notification.py
@@ -148,7 +148,8 @@ class Notification(BaseActivity):
             "level": self.level.name,
             "created": self.created,
             "expires": self.expires,
-            "seen": self.seen
+            "seen": self.seen,
+            "external_key": self.external_key
         }
         return view
 

--- a/feeds/api/api_v1.py
+++ b/feeds/api/api_v1.py
@@ -110,10 +110,16 @@ def add_notification():
     Once validated, will be used as the Source of the notification,
     and used in logic to determine which feeds get notified.
     """
-    if not cfg.debug:
-        service = validate_service_token(get_auth_token(request))  # can also be an admin user
-        if not service:
-            raise InvalidTokenError("Token must come from a service, not a user!")
+    token = get_auth_token(request)
+    try:
+        service = validate_service_token(token)
+    except InvalidTokenError:
+        if cfg.debug:
+            if not is_feeds_admin(token):
+                raise InvalidTokenError('Auth token must be either a Service token '
+                    'or from a user with the FEEDS_ADMIN role!')
+        else:
+            raise
     log(__name__, request.get_data())
     params = _get_notification_params(json.loads(request.get_data()))
     # create a Notification from params.

--- a/feeds/auth.py
+++ b/feeds/auth.py
@@ -108,6 +108,10 @@ def validate_user_ids(user_ids):
 
 
 def get_auth_token(request, required=True):
+    """
+    Returns the auth token from the proper header.
+    If it's not there, and it's required, raises a MissingTokenError.
+    """
     token = request.headers.get('Authorization')
     if not token and required:
         raise MissingTokenError()

--- a/feeds/server.py
+++ b/feeds/server.py
@@ -11,6 +11,11 @@ from flask import (
 import logging
 from http.client import responses
 from flask.logging import default_handler
+from .auth import (
+    get_auth_token,
+    validate_service_token,
+    validate_user_token
+)
 from .util import epoch_ms
 from .config import get_config
 from .exceptions import (
@@ -89,6 +94,29 @@ def create_app(test_config=None):
             "version": VERSION,
             "servertime": epoch_ms()
         })
+
+    @app.route('/permissions', methods=['GET'])
+    @cross_origin()
+    def permissions():
+        """
+        Returns permissions based on the token.
+        """
+        # default permissions without a token
+        perms = {
+            'token': {
+                'user': None,
+                'service': None
+            },
+            'permissions': {
+                'POST': []
+                'GET': ['/notifications/global']
+            }
+        }
+        token = get_auth_token(required=False)
+        if token is not None:
+            try:
+                user = validate_
+
 
     @app.errorhandler(IllegalParameterError)
     @app.errorhandler(json.JSONDecodeError)

--- a/feeds/server.py
+++ b/feeds/server.py
@@ -111,7 +111,7 @@ def create_app(test_config=None):
             },
             'permissions': {
                 'POST': [],
-                'GET': ['/notifications/global']
+                'GET': ['/api/V1/notifications/global']
             }
         }
         token = get_auth_token(request, required=False)

--- a/test/activity/test_notification.py
+++ b/test/activity/test_notification.py
@@ -215,7 +215,8 @@ def test_user_view():
     assert "target" not in v
     assert v["context"] is None
     assert v["level"] == level_name
-    assert "external_key" not in v
+    assert "external_key" in v
+    assert v["external_key"] is None
 
 
 def test_from_dict():
@@ -258,18 +259,6 @@ def test_serialization():
     note = Notification(actor, verb_inf, note_object, source, level=level_id)
     serial = note.serialize()
     json_serial = json.loads(serial)
-        # serial = {
-        #     "i": self.id,
-        #     "a": self.actor,
-        #     "v": self.verb.id,
-        #     "o": self.object,
-        #     "s": self.source,
-        #     "t": self.target,
-        #     "l": self.level.id,
-        #     "c": self.created,
-        #     "e": self.expires,
-        #     "x": self.external_key
-        # }
     assert "i" in json_serial
     assert_is_uuid(json_serial['i'])
     assert "a" in json_serial and json_serial['a'] == actor

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -51,7 +51,9 @@ def mock_valid_user(requests_mock):
     """
     def auth_valid_user(user_id, user_name):
         cfg = test_config()
-        requests_mock.get('{}/api/V2/users?list={}'.format(cfg.get('feeds', 'auth-url'), user_id), text=json.dumps({user_id: user_name}))
+        auth_url = cfg.get('feeds', 'auth-url')
+        requests_mock.get('{}/api/V2/users?list={}'.format(auth_url, user_id),
+            text=json.dumps({user_id: user_name}))
     return auth_valid_user
 
 @pytest.fixture
@@ -66,3 +68,54 @@ def mock_invalid_user(requests_mock):
         cfg = test_config()
         requests_mock.get('{}/api/V2/users?list={}'.format(cfg.get('feeds', 'auth-url'), user_id), text="{}")
     return auth_invalid_user
+
+@pytest.fixture
+def mock_valid_user_token(requests_mock):
+    def auth_valid_user_token(user_id, user_name):
+        cfg = test_config()
+        auth_url = cfg.get('feeds', 'auth-url')
+        requests_mock.get('{}/api/V2/token'.format(auth_url), text=json.dumps({
+            'user': user_id,
+            'type': 'Login',
+            'name': None
+        }))
+        requests_mock.get('{}/api/V2/me'.format(auth_url), text=json.dumps({
+            'customroles': [],
+            'display': user_name,
+            'user': user_id
+        }))
+    return auth_valid_user_token
+
+@pytest.fixture
+def mock_valid_service_token(requests_mock):
+    def auth_valid_service_token(user_id, user_name, service_name):
+        cfg = test_config()
+        auth_url = cfg.get('feeds', 'auth-url')
+        requests_mock.get('{}/api/V2/token'.format(auth_url), text=json.dumps({
+            'user': user_id,
+            'type': 'Service',
+            'name': service_name
+        }))
+        requests_mock.get('{}/api/V2/me'.format(auth_url), text=json.dumps({
+            'customroles': [],
+            'display': user_name,
+            'user': user_id
+        }))
+    return auth_valid_service_token
+
+@pytest.fixture
+def mock_valid_admin_token(request_mock):
+    def auth_valid_admin_token(user_id, user_name):
+        cfg = test_config()
+        auth_url = cfg.get('feeds', 'auth-url')
+        requests_mock.get('{}/api/V2/token'.format(auth_url), text=json.dumps({
+            'user': user_id,
+            'type': 'Login',
+            'name': None
+        }))
+        requests_mock.get('{}/api/V2/me'.format(auth_url), text=json.dumps({
+            'customroles': ['FEEDS_ADMIN'],
+            'display': user_name,
+            'user': user_id
+        }))
+    return auth_valid_admin_token

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -104,7 +104,7 @@ def mock_valid_service_token(requests_mock):
     return auth_valid_service_token
 
 @pytest.fixture
-def mock_valid_admin_token(request_mock):
+def mock_valid_admin_token(requests_mock):
     def auth_valid_admin_token(user_id, user_name):
         cfg = test_config()
         auth_url = cfg.get('feeds', 'auth-url')

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -26,15 +26,6 @@ def test_validate_service_token_ok(requests_mock):
                       text=json.dumps({}))
     assert (validate_service_token(token) == test_name)
 
-    # test feeds admin user token
-    token = 'fake_token' + str(uuid.uuid4())
-    test_user = 'test_user'
-    requests_mock.get('{}/api/V2/token'.format(cfg.get('feeds', 'auth-url')),
-                      text=json.dumps({'user': test_user}))
-    requests_mock.get('{}/api/V2/me'.format(cfg.get('feeds', 'auth-url')),
-                      text=json.dumps({'customroles': ['FEEDS_ADMIN']}))
-    assert (validate_service_token(token) == test_user)
-
 
 def test_validate_service_token_fail(requests_mock):
 
@@ -51,14 +42,14 @@ def test_validate_service_token_fail(requests_mock):
 
 
 def test_is_feeds_admin_ok(requests_mock):
-    # test service token
+    # test service token - should fail
     token = 'fake_token' + str(uuid.uuid4())
     test_name = 'test_name'
     requests_mock.get('{}/api/V2/token'.format(cfg.get('feeds', 'auth-url')),
                       text=json.dumps({'type': 'Service', 'name': test_name}))
     requests_mock.get('{}/api/V2/me'.format(cfg.get('feeds', 'auth-url')),
                       text=json.dumps({}))
-    assert is_feeds_admin(token)
+    assert is_feeds_admin(token) == False
 
     # test feeds admin user token
     token = 'fake_token' + str(uuid.uuid4())

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -4,6 +4,7 @@ import json
 import pytest
 from pprint import pprint
 from .conftest import test_config
+from uuid import uuid4
 cfg = test_config()
 
 @pytest.mark.parametrize('path', (
@@ -53,27 +54,52 @@ def test_permissions_noauth(client, requests_mock):
     assert 'token' in data
     assert data['token'] == {'service': None, 'user': None, 'admin': False}
     assert 'permissions' in data
-    assert data['permissions'] == {'GET': ['/notifications/global'], 'POST': []}
+    assert data['permissions'] == {'GET': ['/api/V1/notifications/global'], 'POST': []}
 
 def test_permissions_user(client, requests_mock, mock_valid_user_token):
     user_id = 'a_user'
     user_name = 'A User'
     mock_valid_user_token(user_id, user_name)
-    response = client.get('/permissions', headers={'Authorization': 'foo'})
+    response = client.get('/permissions', headers={'Authorization': 'test_token'+str(uuid4())})
     data = json.loads(response.data)
-    print("TEST USER PERMISSIONS --- {}".format(data))
+    assert 'token' in data
+    assert data['token'] == {'service': None, 'user': user_id, 'admin': False}
+    assert 'permissions' in data
+    assert 'GET' in data['permissions']
+    valid_gets = set(['/api/V1/notifications/global', '/api/V1/notifications', '/api/V1/notification/<note_id>'])
+    assert valid_gets == set(data['permissions']['GET'])
+    valid_posts = set(['/api/V1/notifications/see', '/api/V1/notifications/unsee'])
+    assert valid_posts == set(data['permissions']['POST'])
 
-def test_permissions_service(client, requests_mock):
-    test_name = 'SomeService'
-    requests_mock.get('{}/api/V2/token'.format(cfg.get('feeds', 'auth-url')),
-                      text=json.dumps({'type': 'Service', 'name': test_name}))
-    requests_mock.get('{}/api/V2/me'.format(cfg.get('feeds', 'auth-url')),
-                      text=json.dumps({}))
 
-def test_permissions_admin(client, requests_mock):
-    test_name = 'SomeService'
-    requests_mock.get('{}/api/V2/token'.format(cfg.get('feeds', 'auth-url')),
-                      text=json.dumps({'type': 'Service', 'name': test_name}))
-    requests_mock.get('{}/api/V2/me'.format(cfg.get('feeds', 'auth-url')),
-                      text=json.dumps({}))
+def test_permissions_service(client, requests_mock, mock_valid_service_token):
+    service_name = 'SomeService'
+    user_id = 'service_user'
+    user_name = 'Service User'
+    mock_valid_service_token(user_id, user_name, service_name)
+    response = client.get('/permissions', headers={'Authorization': 'serv_token-'+str(uuid4())})
+    data = json.loads(response.data)
+    assert 'token' in data
+    assert data['token'] == {'service': service_name, 'user': user_id, 'admin': False}
+    assert 'permissions' in data
+    assert 'GET' in data['permissions']
+    valid_gets = set(['/api/V1/notifications/global', '/api/V1/notifications', '/api/V1/notification/<note_id>'])
+    assert valid_gets == set(data['permissions']['GET'])
+    valid_posts = set(['/api/V1/notifications/see', '/api/V1/notifications/unsee', '/api/V1/notification'])
+    assert valid_posts == set(data['permissions']['POST'])
 
+
+def test_permissions_admin(client, requests_mock, mock_valid_admin_token):
+    user_id = 'service_user'
+    user_name = 'Service User'
+    mock_valid_admin_token(user_id, user_name)
+    response = client.get('/permissions', headers={'Authorization': 'admin_token-'+str(uuid4())})
+    data = json.loads(response.data)
+    assert 'token' in data
+    assert data['token'] == {'service': None, 'user': user_id, 'admin': True}
+    assert 'permissions' in data
+    assert 'GET' in data['permissions']
+    valid_gets = set(['/api/V1/notifications/global', '/api/V1/notifications', '/api/V1/notification/<note_id>'])
+    assert valid_gets == set(data['permissions']['GET'])
+    valid_posts = set(['/api/V1/notifications/see', '/api/V1/notifications/unsee', '/api/V1/notification/global'])
+    assert valid_posts == set(data['permissions']['POST'])


### PR DESCRIPTION
Going to this endpoint will show what paths will work, based on a user's token. There's 3 types right now - plain users who want to view and mark their feeds as seen/unseen, a Service who gets to post a notification, and an Admin who gets to post a global notification.

This also exposes the external key, if present, in the returned notification structure.