### PR TITLE
Bump number of gunicorn workers to 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ test:
 	pytest --verbose test --cov=feeds --cov-report html feeds -s
 
 start:
-	gunicorn --worker-class gevent --timeout 300 --workers 17 --bind :5000 feeds.server:app
+	gunicorn --worker-class gevent --timeout 300 --workers 5 --bind :5000 feeds.server:app
 
 .PHONY: test docs

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ test:
 	pytest --verbose test --cov=feeds --cov-report html feeds -s
 
 start:
-	gunicorn --worker-class gevent --timeout 300 --workers 1 --bind :5000 feeds.server:app
+	gunicorn --worker-class gevent --timeout 300 --workers 17 --bind :5000 feeds.server:app
 
 .PHONY: test docs


### PR DESCRIPTION
The rule of thumb is (2 x number of cores) + 1 (http://docs.gunicorn.org/en/stable/design.html#how-many-workers). Not sure how many cores this service will get, but let's go with 2.

