### PR TITLE
Add endpoint to lookup a notification by external key

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ If you have the id of a notification and want to get its structure, just add it 
 * Path: `/api/V1/notification/<note_id>`
 * Method: `GET`
 * Required header: `Authorization`
-* Returns: a single Notification
+* Returns: a JSON object with a "notification" key where the value is the requested Notification.
 * Possible errors:
     * 404 Not Found
         * If the notification does not exist.
@@ -165,6 +165,18 @@ To just return the list of global notifications, use the global path. It returns
 * Method: `GET`
 * Required header: none
 * Returns: a list of Notifications
+
+### Get a single notification from an external key
+**(debug method)**  
+This is meant for services to debug their use of external keys. A service that created a notification with an external key can fetch that notification using that key and the auth token that created it (i.e. the proof it came from that service). As in getting a notification above, this returns a JSON object with a "notification" key and a single notification attached to it. Also, in contrast to the method above, this returns the entire Notification document as stored in the database (including the list of users it is intended for and whether they've marked it as seen).
+* Path: `/api/V1/notification/external_key/<key>`
+* Method: `GET`
+* Required header: `Authorization`
+* Returns: a JSON object with a "notification" key where the value is the requested Notification. This includes extra data that's stored in the database as well, but not usually available to users.
+* Possible errors:
+    * 404 Not Found - If the notification does not exist with that combination of external key and source.
+    * 401 Not Authenticated - if no auth token is provided.
+    * 403 Forbidden - If the token is invalid, or not a Service token.
 
 ### Create a new notification
 Only services (i.e. those Authorization tokens with type=Service, as told by the Auth service) can use this endpoint to create a new notification. This requires the body to be a JSON structure with the following available keys (pretty similar to the Notification structure above):

--- a/feeds/api/api_v1.py
+++ b/feeds/api/api_v1.py
@@ -172,6 +172,28 @@ def get_global_notifications():
     return flask.jsonify(global_notes)
 
 
+@api_v1.route('/notification/external_key/<ext_key>', methods=['GET'])
+@cross_origin()
+def get_notification_by_ext_key(ext_key):
+    """
+    Intended for debugging, this returns the notification by
+    external key for a service token. The service must match the
+    source of the notification.
+    """
+    service = validate_service_token(get_auth_token(request))
+    manager = NotificationManager()
+    notes = manager.get_notifications_by_ext_keys([ext_key], service)
+    note = notes.get(ext_key)
+    if note is None:
+        raise NotificationNotFoundError(
+            "Cannot find notification with external_key {} and "
+            "source {}.".format(ext_key, service)
+        )
+    if "_id" in note:    # Don't need the internal Mongo record id here.
+        del note["_id"]
+    return (flask.jsonify({'notification': notes[ext_key]}), 200)
+
+
 @api_v1.route('/notification/<note_id>', methods=['GET'])
 @cross_origin()
 def get_single_notification(note_id):

--- a/feeds/managers/notification_manager.py
+++ b/feeds/managers/notification_manager.py
@@ -6,7 +6,10 @@ user feeds, based on the content and context of the Notification.
 See also the docs in NotificationFeed.
 """
 
-from typing import List
+from typing import (
+    List,
+    Dict
+)
 from .base import BaseManager
 from ..activity.notification import Notification
 from ..storage.mongodb.activity_storage import MongoActivityStorage
@@ -98,3 +101,14 @@ class NotificationManager(BaseManager):
             "unauthorized": unauthorized,
             "expired": expired
         }
+
+    def get_notifications_by_ext_keys(self, external_keys: List[str], source: str) -> Dict:
+        """
+        Fetches notifications by their external key and source.
+        These are returned as a dictionary where the keys are the
+        external_keys and values are notifications. Any notifications
+        that don't match the criteria are just returned as None.
+        """
+        assert source is not None
+        storage = MongoActivityStorage()
+        return storage.get_by_external_key(external_keys, source)

--- a/feeds/server.py
+++ b/feeds/server.py
@@ -138,6 +138,7 @@ def create_app(test_config=None):
                 service = validate_service_token(token)
                 # TODO - add filter so only specific services can see these
                 perms['token']['service'] = service
+                perms['permissions']['GET'].append('/api/V1/notification/external_key/<key>')
                 perms['permissions']['POST'].append('/api/V1/notification')
             except InvalidTokenError:
                 pass

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -85,7 +85,7 @@ def test_permissions_service(client, requests_mock, mock_valid_service_token):
     assert data['token'] == {'service': service_name, 'user': user_id, 'admin': False}
     assert 'permissions' in data
     assert 'GET' in data['permissions']
-    valid_gets = set(['/api/V1/notifications/global', '/api/V1/notifications', '/api/V1/notification/<note_id>'])
+    valid_gets = set(['/api/V1/notifications/global', '/api/V1/notifications', '/api/V1/notification/<note_id>', '/api/V1/notification/external_key/<key>'])
     assert valid_gets == set(data['permissions']['GET'])
     valid_posts = set(['/api/V1/notifications/see', '/api/V1/notifications/unsee', '/api/V1/notification'])
     assert valid_posts == set(data['permissions']['POST'])


### PR DESCRIPTION
Works like this:
`GET /api/V1/notification/external_key/<key>`

This **only** works when the auth header contains a Service token, and that service was used to create the Notification. That is, the `source` key matches the service.

If those criteria aren't matched, returns a 404 error.