### PR TITLE
SCT-1701 unread count

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ Options are included to filter by level, source, whether a notification has been
 ```
 {
     "global": {
-        "unread": <number unread>,
+        "unseen": <number unseen>,
         "feed": [ array of global notifications ]
     },
     "user": {
-        "unread": <number unread>,
+        "unseen": <number unseen>,
         "feed": [ array of user's notifications ]
     }
 }

--- a/feeds/feeds/notification/notification_feed.py
+++ b/feeds/feeds/notification/notification_feed.py
@@ -32,13 +32,16 @@ class NotificationFeed(BaseFeed):
             count=count, include_seen=include_seen, verb=verb,
             level=level, reverse=reverse, user_view=user_view
         )
+        ret_struct = {
+            "unseen": self.get_unseen_count()
+        }
         if user_view:
-            ret_list = list()
+            ret_struct["feed"] = list()
             for act in activities:
-                ret_list.append(act.user_view())
-            return ret_list
+                ret_struct["feed"].append(act.user_view())
         else:
-            return activities
+            ret_struct["feed"] = activities
+        return ret_struct
 
     def get_notification(self, note_id):
         """
@@ -98,3 +101,9 @@ class NotificationFeed(BaseFeed):
         Adds an activity to this user's feed
         """
         self.activity_storage.add_to_storage(note, [self.user_id])
+
+    def get_unseen_count(self):
+        """
+        Returns the number of unread / unexpired notifications in this feed.
+        """
+        return self.timeline_storage.get_unseen_count()

--- a/feeds/storage/mongodb/activity_storage.py
+++ b/feeds/storage/mongodb/activity_storage.py
@@ -32,7 +32,7 @@ class MongoActivityStorage(ActivityStorage):
         coll = get_feeds_collection()
         coll.update_many({
             'id': {'$in': act_ids},
-            'users': {'$all': [user]},
+            'users': user,
             'unseen': {'$nin': [user]}
         }, {
             '$addToSet': {'unseen': user}
@@ -48,7 +48,7 @@ class MongoActivityStorage(ActivityStorage):
         coll = get_feeds_collection()
         coll.update_many({
             'id': {'$in': act_ids},
-            'users': {'$all': [user]},
+            'users': user,
             'unseen': {'$all': [user]}
         }, {
             '$pull': {'unseen': user}

--- a/feeds/storage/mongodb/timeline_storage.py
+++ b/feeds/storage/mongodb/timeline_storage.py
@@ -54,8 +54,12 @@ class MongoTimelineStorage(TimelineStorage):
             note_serial['seen'] = True
         return note_serial
 
-    # def get_unread_timeline(self):
-    #     coll = get_feeds_collection()
-    #     query = {
-    #         "users": self.user_id
-    #     }
+    def get_unseen_count(self):
+        coll = get_feeds_collection()
+        now = epoch_ms()
+        query = {
+            "users": self.user_id,
+            "unseen": self.user_id,
+            "expires": {"$gt": now}
+        }
+        return coll.find(query).count()

--- a/feeds/storage/mongodb/timeline_storage.py
+++ b/feeds/storage/mongodb/timeline_storage.py
@@ -43,7 +43,7 @@ class MongoTimelineStorage(TimelineStorage):
         coll = get_feeds_collection()
         query = {
             "id": note_id,
-            "users": {"$all": [self.user_id]}
+            "users": self.user_id
         }
         note_serial = coll.find_one(query)
         if note_serial is None:
@@ -53,3 +53,9 @@ class MongoTimelineStorage(TimelineStorage):
         else:
             note_serial['seen'] = True
         return note_serial
+
+    # def get_unread_timeline(self):
+    #     coll = get_feeds_collection()
+    #     query = {
+    #         "users": self.user_id
+    #     }


### PR DESCRIPTION
Add counts of unseen notifications for each feed queried.

This changes the result structure of `GET /notifications` (and `GET /notifications/global`) from
```
{
    global: [note array],
    user: [note array]
}
```
to
```
{
    global: {
        feed: [note array],
        unseen: int
    },
    user: {
        feed: [note array],
        unseen: int
    }
}
```