### PR TITLE
Make an unseen_count endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Doesn't return the notifications at all, just how many unseen ones there are for
 * Path: `/api/V1/notifications/unseen_count`
 * Method: `GET`
 * Required header: `Authorization`
-* Returns: a JSON object with an "unseen" key where the value is the number of unseen notifications.
+* Returns: a JSON object with an "unseen" key. This key is a small structure with "user" and "global" keys, where the values of those are the number of unseen notifications in each. For the user feed, this is summed across all feeds the user is subscribed to.
 * Possible errors:
     * 401 Not Authenticated - If an auth token is not provided.
     * 403 Forbidden -If an invalid auth token is provided.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ curl -X GET
      https://<service_url>/api/V1/notifications?seen=0&n=50&v=share&l=warning
 ```
 
+### Get count of unseen notifications
+Doesn't return the notifications at all, just how many unseen ones there are for the given user. Should be pretty performant, and certainly light on data transfer.
+* Path: `/api/V1/notifications/unseen_count`
+* Method: `GET`
+* Required header: `Authorization`
+* Returns: a JSON object with an "unseen" key where the value is the number of unseen notifications.
+* Possible errors:
+    * 401 Not Authenticated - If an auth token is not provided.
+    * 403 Forbidden -If an invalid auth token is provided.
+
 ### Get a single notification
 If you have the id of a notification and want to get its structure, just add it to the path. This will search the user's feed for that notification. If present on the user's feed, it will be returned. If not present, or if this notification cannot be seen by the user, this will raise a "404 Not Found" error.
 * Path: `/api/V1/notification/<note_id>`

--- a/feeds/api/api_v1.py
+++ b/feeds/api/api_v1.py
@@ -28,7 +28,8 @@ from feeds.verbs import translate_verb
 from .util import (
     parse_notification_params,
     parse_expire_notifications_params,
-    fetch_global_notifications
+    fetch_global_notifications,
+    get_global_feed
 )
 
 cfg = get_config()
@@ -177,7 +178,16 @@ def get_unseen_notification_count():
     user_token = get_auth_token(request)
     user_id = validate_user_token(user_token)
     feed = NotificationFeed(user_id, "user", token=user_token)
-    return (flask.jsonify({'unseen': feed.get_unseen_count()}), 200)
+    user_count = feed.get_unseen_count()
+    global_feed = get_global_feed()
+    global_count = global_feed.get_unseen_count()
+    ret_value = {
+        "unseen": {
+            "user": user_count,
+            "global": global_count
+        }
+    }
+    return (flask.jsonify(ret_value), 200)
 
 
 @api_v1.route('/notification/external_key/<ext_key>/source/<source>', methods=['GET'])

--- a/feeds/api/api_v1.py
+++ b/feeds/api/api_v1.py
@@ -168,7 +168,16 @@ def add_notification():
 @api_v1.route('/notifications/global', methods=['GET'])
 @cross_origin()
 def get_global_notifications():
-    return flask.jsonify(fetch_global_notifications())
+    return (flask.jsonify(fetch_global_notifications()), 200)
+
+
+@api_v1.route('/notifications/unseen_count', methods=['GET'])
+@cross_origin()
+def get_unseen_notification_count():
+    user_token = get_auth_token(request)
+    user_id = validate_user_token(user_token)
+    feed = NotificationFeed(user_id, "user", token=user_token)
+    return (flask.jsonify({'unseen': feed.get_unseen_count()}), 200)
 
 
 @api_v1.route('/notification/external_key/<ext_key>/source/<source>', methods=['GET'])

--- a/feeds/api/util.py
+++ b/feeds/api/util.py
@@ -114,6 +114,11 @@ def fetch_global_notifications(count=0) -> dict:
     cfg = get_config()
     if count == 0:
         count = cfg.default_max_notes
-    global_feed = NotificationFeed(cfg.global_feed, cfg.global_feed_type)
+    global_feed = get_global_feed()
     global_notes = global_feed.get_notifications(count=count, user_view=True)
     return global_notes
+
+
+def get_global_feed() -> NotificationFeed:
+    cfg = get_config()
+    return NotificationFeed(cfg.global_feed, cfg.global_feed_type)

--- a/feeds/feeds/notification/notification_feed.py
+++ b/feeds/feeds/notification/notification_feed.py
@@ -141,7 +141,7 @@ class NotificationFeed(BaseFeed):
             note_list.append(Notification.from_dict(note, self.token))
         return note_list
 
-    def mark_activities(self, activity_ids, seen=False):
+    def mark_activities(self, activity_ids: List[str], seen=False) -> None:
         """
         Marks the given list of activities as either seen (True) or unseen (False).
         If the owner of this feed is not on the users list for an activity, nothing is
@@ -152,16 +152,16 @@ class NotificationFeed(BaseFeed):
         else:
             self.activity_storage.set_unseen(activity_ids, self.user)
 
-    def add_notification(self, note):
+    def add_notification(self, note) -> None:
         return self.add_activity(note)
 
-    def add_activity(self, note):
+    def add_activity(self, note) -> None:
         """
         Adds an activity to this user's feed
         """
         self.activity_storage.add_to_storage(note, [self.user])
 
-    def get_unseen_count(self):
+    def get_unseen_count(self) -> int:
         """
         Returns the number of unread / unexpired notifications in this feed.
         """

--- a/feeds/server.py
+++ b/feeds/server.py
@@ -33,7 +33,7 @@ from feeds.logger import (
     log_error
 )
 
-VERSION = "0.1.4"
+VERSION = "0.2.0"
 
 try:
     from feeds import gitcommit

--- a/test/api/test_api_v1.py
+++ b/test/api/test_api_v1.py
@@ -570,6 +570,32 @@ def test_expire_notifications_user_auth(client, mock_valid_user_token):
     assert data['error']['message'] == 'Authentication token must be a Service token.'
 
 
+###
+# GET /unseen_count
+###
+
+def test_get_unseen_count(client, mock_valid_user_token):
+    mock_valid_user_token('test_user', 'Test User')
+    response = client.get('/api/V1/notifications/unseen_count', headers={"Authorization": "token-"+str(uuid4())})
+    data = json.loads(response.data)
+    assert 'unseen' in data
+    assert data['unseen'] == 7
+
+def test_get_unseen_count_no_auth(client):
+    response = client.get('/api/V1/notifications/unseen_count')
+    data = json.loads(response.data)
+    assert 'error' in data
+    assert data['error']['http_code'] == 401
+    assert data['error']['message'] == 'Authentication token required'
+
+def test_get_unseen_count_invalid_auth(client, mock_invalid_user_token):
+    mock_invalid_user_token('fake_user')
+    response = client.get('/api/V1/notifications/unseen_count', headers={"Authorization": "bad_token-"+str(uuid4())})
+    data = json.loads(response.data)
+    assert 'error' in data
+    assert data['error']['http_code'] == 403
+
+
 def _validate_notification(note):
     """
     Validates the structure of a user's notification.

--- a/test/api/test_api_v1.py
+++ b/test/api/test_api_v1.py
@@ -579,7 +579,10 @@ def test_get_unseen_count(client, mock_valid_user_token):
     response = client.get('/api/V1/notifications/unseen_count', headers={"Authorization": "token-"+str(uuid4())})
     data = json.loads(response.data)
     assert 'unseen' in data
-    assert data['unseen'] == 7
+    assert 'user' in data['unseen']
+    assert data['unseen']['user'] == 7
+    assert 'global' in data['unseen']
+    assert data['unseen']['global'] == 1
 
 def test_get_unseen_count_no_auth(client):
     response = client.get('/api/V1/notifications/unseen_count')


### PR DESCRIPTION
Makes this endpoint - `api/V2/notifications/unseen_count` that just returns the total number of unseen notifications summed across all categories for a user's feed. Includes the global feed count as well.

Returns a structure like this:
```
{
    'unseen': {
        'global': ##,
        'user': ##
    }
}
```